### PR TITLE
Swift 2.3 Support

### DIFF
--- a/Magic Sample Project/Magic Sample Project.xcodeproj/project.pbxproj
+++ b/Magic Sample Project/Magic Sample Project.xcodeproj/project.pbxproj
@@ -179,9 +179,13 @@
 				TargetAttributes = {
 					550697C31C685685008C5BAF = {
 						CreatedOnToolsVersion = 7.2.1;
+						DevelopmentTeam = HT94948NDD;
+						LastSwiftMigration = 0800;
 					};
 					8E146AC61BA00A8300CA4781 = {
 						CreatedOnToolsVersion = 7.0;
+						DevelopmentTeam = HT94948NDD;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -275,8 +279,10 @@
 		550697CD1C685686008C5BAF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -287,6 +293,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Sabintsev.Magic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -297,6 +304,7 @@
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -307,6 +315,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Sabintsev.Magic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -399,11 +408,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Magic Sample Project/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sabintsev.Magic-Sample-Project";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -411,11 +422,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Magic Sample Project/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sabintsev.Magic-Sample-Project";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -429,6 +442,7 @@
 				550697CE1C685686008C5BAF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8E146AC21BA00A8300CA4781 /* Build configuration list for PBXProject "Magic Sample Project" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Converted code base to Swift 2.3 using Xcode8b4.

Please note that when Xcode 8 GM comes out, the `master` branch will begin pointing to the Swift 3 code base that is currently found on the `swift3` branch.
